### PR TITLE
Fix deprecated aws_region .name attribute

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -8,7 +8,7 @@ locals {
     "  backend \"s3\" {",
     "    bucket         = \"${module.primary_s3.bucket}\"",
     "    key            = \"terraform.tfstate\"",
-    "    region         = \"${data.aws_region.current.name}\"",
+    "    region         = \"${data.aws_region.current.id}\"",
     "    dynamodb_table = \"${one(aws_dynamodb_table.default[*]).name}\"",
     "    encrypt        = true",
     "  }",


### PR DESCRIPTION
## Summary
- Replace `data.aws_region.current.name` with `data.aws_region.current.id` in the `backend_config` local
- The `.name` attribute is deprecated in newer AWS provider versions; `.id` returns the same value (e.g. `us-east-1`)

## Test plan
- [ ] Run `terraform plan` and confirm no deprecation warning for `data.aws_region.current.name`
- [ ] Verify `backend_config` output still contains the correct region

🤖 Generated with [Claude Code](https://claude.com/claude-code)